### PR TITLE
when i run rake spree_store_credits:install that time error is occurred ...

### DIFF
--- a/lib/spree_affiliate_hooks.rb
+++ b/lib/spree_affiliate_hooks.rb
@@ -4,6 +4,24 @@ class SpreeAffiliateHooks < Spree::ThemeSupport::HookListener
                      :insert_after => "[data-hook='admin_configurations_menu'], #admin_configurations_menu[data-hook]",
                      :text => "<%= configurations_menu_item(I18n.t('captcha.captcha_settings'), admin_captcha_settings_path, I18n.t('captcha.manage_keys')) %>",
                      :disabled => false)
+  Deface::Override.new(:virtual_path => "products/show",
+                     :name => "converted_product_description_854642347",
+                     :insert_after => "[data-hook='product_description'], #product_description[data-hook]",
+                     :text => "<p class=\"email_to_friend\">
+        <%= link_to(t('email_to_friend.send_to_friend'), email_to_friend_url('product', @product)) %>
+    </p>",
+                     :disabled => false)  
+  Deface::Override.new(:virtual_path => "admin/configurations/index",
+                     :name => "converted_admin_configurations_menu_308554151",
+                     :insert_after => "[data-hook='admin_configurations_menu'], #admin_configurations_menu[data-hook]",
+                     :text => "<%= configurations_menu_item(I18n.t('affiliate_settings'), admin_affiliate_settings_path, I18n.t('manage_affiliate_settings')) %>",
+                     :disabled => false)
+  Deface::Override.new(:virtual_path => "users/show",
+                     :name => "converted_account_my_orders_575876979",
+                     :insert_before => "[data-hook='account_my_orders'], #account_my_orders[data-hook]",
+                     :partial => "users/affiliate",
+                     :disabled => false)
+                 
 
   
   insert_before :account_my_orders, :partial => 'users/affiliate'

--- a/lib/spree_affiliate_hooks.rb
+++ b/lib/spree_affiliate_hooks.rb
@@ -1,7 +1,10 @@
 class SpreeAffiliateHooks < Spree::ThemeSupport::HookListener
-  insert_after :admin_configurations_menu do
-    "<%= configurations_menu_item(I18n.t('affiliate_settings'), admin_affiliate_settings_path, I18n.t('manage_affiliate_settings')) %>"
-  end
+  Deface::Override.new(:virtual_path => "admin/configurations/index",
+                     :name => "converted_admin_configurations_menu_404040658",
+                     :insert_after => "[data-hook='admin_configurations_menu'], #admin_configurations_menu[data-hook]",
+                     :text => "<%= configurations_menu_item(I18n.t('captcha.captcha_settings'), admin_captcha_settings_path, I18n.t('captcha.manage_keys')) %>",
+                     :disabled => false)
+
   
   insert_before :account_my_orders, :partial => 'users/affiliate'
   

--- a/lib/spree_affiliate_hooks.rb
+++ b/lib/spree_affiliate_hooks.rb
@@ -1,27 +1,7 @@
 class SpreeAffiliateHooks < Spree::ThemeSupport::HookListener
-  Deface::Override.new(:virtual_path => "admin/configurations/index",
-                     :name => "converted_admin_configurations_menu_404040658",
-                     :insert_after => "[data-hook='admin_configurations_menu'], #admin_configurations_menu[data-hook]",
-                     :text => "<%= configurations_menu_item(I18n.t('captcha.captcha_settings'), admin_captcha_settings_path, I18n.t('captcha.manage_keys')) %>",
-                     :disabled => false)
-  Deface::Override.new(:virtual_path => "products/show",
-                     :name => "converted_product_description_854642347",
-                     :insert_after => "[data-hook='product_description'], #product_description[data-hook]",
-                     :text => "<p class=\"email_to_friend\">
-        <%= link_to(t('email_to_friend.send_to_friend'), email_to_friend_url('product', @product)) %>
-    </p>",
-                     :disabled => false)  
-  Deface::Override.new(:virtual_path => "admin/configurations/index",
-                     :name => "converted_admin_configurations_menu_308554151",
-                     :insert_after => "[data-hook='admin_configurations_menu'], #admin_configurations_menu[data-hook]",
-                     :text => "<%= configurations_menu_item(I18n.t('affiliate_settings'), admin_affiliate_settings_path, I18n.t('manage_affiliate_settings')) %>",
-                     :disabled => false)
-  Deface::Override.new(:virtual_path => "users/show",
-                     :name => "converted_account_my_orders_575876979",
-                     :insert_before => "[data-hook='account_my_orders'], #account_my_orders[data-hook]",
-                     :partial => "users/affiliate",
-                     :disabled => false)
-                 
+ insert_after :admin_configurations_menu do
+    "<%= configurations_menu_item(I18n.t('affiliate_settings'), admin_affiliate_settings_path, I18n.t('manage_affiliate_settings')) %>"
+  end
 
   
   insert_before :account_my_orders, :partial => 'users/affiliate'


### PR DESCRIPTION
...

[DEPRECATION] `insert_after` hook method is deprecated, replace hook call with: 
Deface::Override.new(:virtual_path => "admin/configurations/index",
                     :name => "converted_admin_configurations_menu_404040658",
                     :insert_after => "[data-hook='admin_configurations_menu'], #admin_configurations_menu[data-hook]",
                     :text => "<%= configurations_menu_item(I18n.t('captcha.captcha_settings'), admin_captcha_settings_path, I18n.t('captcha.manage_keys')) %>",
                     :disabled => false)
